### PR TITLE
decode - handle unexpected end of stream

### DIFF
--- a/src/decode.js
+++ b/src/decode.js
@@ -53,6 +53,9 @@ function decodeFromReader (reader, opts, cb) {
 
 function readFixedMessage (reader, byteLength, cb) {
   reader.read(byteLength, (err, bytes) => {
+    if (err === true) {
+      return cb(new Error('Unexpected end of stream.'))
+    }
     if (err) {
       return cb(err)
     }
@@ -69,6 +72,9 @@ function readVarintMessage (reader, cb) {
   // 1. Read the varint
   function readByte () {
     reader.read(1, (err, byte) => {
+      if (err === true) {
+        return cb(new Error('Unexpected end of stream.'))
+      }
       if (err) {
         return cb(err)
       }


### PR DESCRIPTION
pull streams emit 'true' or an error on drain.
( see https://github.com/pull-stream/pull-stream#source-aka-readable )

I was getting a case where the source was unexpectedly ending, and 'true' was being passed up as the error. `decodeFromReader` seemed like the correct place to handle this case, as it is the end of pull streams and the start of a error-first-cb api.