### PR TITLE
Tests and guards for failure cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "varint": "^4.0.1"
   },
   "devDependencies": {
-    "aegir": "^6.0.0",
+    "aegir": "^9.1.2",
     "chai": "^3.5.0",
     "pull-block": "^1.0.1",
     "pull-stream": "^3.4.3"

--- a/src/decode.js
+++ b/src/decode.js
@@ -99,6 +99,9 @@ function readVarintMessage (reader, cb) {
 
         rawMsgSize = []
 
+        if (msg.length < msgSize) {
+          return cb (new Error('Message length does not match prefix specified length.'))
+        }
         cb(null, msg)
       })
     })

--- a/src/decode.js
+++ b/src/decode.js
@@ -40,7 +40,7 @@ function decodeFromReader (reader, opts, cb) {
     opts = {}
   }
 
-  _decodeFromReader(reader, opts, function onComplete(err, msg){
+  _decodeFromReader(reader, opts, function onComplete (err, msg) {
     if (err) {
       if (err === true) return cb(new Error('Unexpected end of input from reader.'))
       return cb(err)
@@ -100,7 +100,7 @@ function readVarintMessage (reader, cb) {
         rawMsgSize = []
 
         if (msg.length < msgSize) {
-          return cb (new Error('Message length does not match prefix specified length.'))
+          return cb(new Error('Message length does not match prefix specified length.'))
         }
         cb(null, msg)
       })

--- a/src/decode.js
+++ b/src/decode.js
@@ -20,7 +20,7 @@ function decode (opts) {
   return (read) => {
     reader(read)
     function next () {
-      decodeFromReader(reader, opts, (err, msg) => {
+      _decodeFromReader(reader, opts, (err, msg) => {
         if (err) return p.end(err)
 
         p.push(msg)
@@ -33,12 +33,23 @@ function decode (opts) {
   }
 }
 
+// wrapper to detect sudden pull-stream disconnects
 function decodeFromReader (reader, opts, cb) {
   if (typeof opts === 'function') {
     cb = opts
     opts = {}
   }
 
+  _decodeFromReader(reader, opts, function onComplete(err, msg){
+    if (err) {
+      if (err === true) return cb(new Error('Unexpected end of input from reader.'))
+      return cb(err)
+    }
+    cb(null, msg)
+  })
+}
+
+function _decodeFromReader (reader, opts, cb) {
   opts = Object.assign({
     fixed: false,
     bytes: 4

--- a/test/decode.spec.js
+++ b/test/decode.spec.js
@@ -1,0 +1,62 @@
+/* eslint-env mocha */
+'use strict'
+
+const pull = require('pull-stream')
+const Reader = require('pull-reader')
+const expect = require('chai').expect
+const varint = require('varint')
+const block = require('pull-block')
+
+const lp = require('../src')
+
+describe('pull-length-prefixed decode', () => {
+  it('decodeFromReader', (done) => {
+
+    const input = [
+      new Buffer('haay wuurl!')
+    ]
+
+    const reader = Reader(1e3)
+    
+    // length-prefix encode input
+    pull(
+      pull.values(input),
+      lp.encode(),
+      reader
+    )
+
+    // decode from reader
+    lp.decodeFromReader(reader, function(err, output){
+      if (err) throw err
+      expect(
+        output
+      ).to.be.eql(
+        input[0]
+      )
+      done()
+    })
+
+  })
+
+  it('decodeFromReader - empty input', (done) => {
+
+    const input = []
+
+    const reader = Reader(1e3)
+    
+    // length-prefix encode input
+    pull(
+      pull.values(input),
+      lp.encode(),
+      reader
+    )
+
+    // decode from reader
+    lp.decodeFromReader(reader, function(err, output){
+      expect(err).to.exist
+      expect(err).to.be.instanceof(Error)
+      done()
+    })
+
+  })
+})

--- a/test/fromReader.spec.js
+++ b/test/fromReader.spec.js
@@ -9,8 +9,8 @@ const block = require('pull-block')
 
 const lp = require('../src')
 
-describe('pull-length-prefixed decode', () => {
-  it('decodeFromReader', (done) => {
+describe('pull-length-prefixed decodeFromReader', () => {
+  it('basic', (done) => {
 
     const input = [
       new Buffer('haay wuurl!')
@@ -38,7 +38,7 @@ describe('pull-length-prefixed decode', () => {
 
   })
 
-  it('decodeFromReader - empty input', (done) => {
+  it('empty input', (done) => {
 
     const input = []
 
@@ -55,6 +55,7 @@ describe('pull-length-prefixed decode', () => {
     lp.decodeFromReader(reader, function(err, output){
       expect(err).to.exist
       expect(err).to.be.instanceof(Error)
+      expect(output).to.not.exist
       done()
     })
 

--- a/test/fromReader.spec.js
+++ b/test/fromReader.spec.js
@@ -4,20 +4,17 @@
 const pull = require('pull-stream')
 const Reader = require('pull-reader')
 const expect = require('chai').expect
-const varint = require('varint')
-const block = require('pull-block')
 
 const lp = require('../src')
 
 describe('pull-length-prefixed decodeFromReader', () => {
   it('basic', (done) => {
-
     const input = [
       new Buffer('haay wuurl!')
     ]
 
     const reader = Reader(1e3)
-    
+
     // length-prefix encode input
     pull(
       pull.values(input),
@@ -26,7 +23,7 @@ describe('pull-length-prefixed decodeFromReader', () => {
     )
 
     // decode from reader
-    lp.decodeFromReader(reader, function(err, output){
+    lp.decodeFromReader(reader, function (err, output) {
       if (err) throw err
       expect(
         output
@@ -35,15 +32,13 @@ describe('pull-length-prefixed decodeFromReader', () => {
       )
       done()
     })
-
   })
 
   it('empty input', (done) => {
-
     const input = []
 
     const reader = Reader(1e3)
-    
+
     // length-prefix encode input
     pull(
       pull.values(input),
@@ -52,12 +47,11 @@ describe('pull-length-prefixed decodeFromReader', () => {
     )
 
     // decode from reader
-    lp.decodeFromReader(reader, function(err, output){
+    lp.decodeFromReader(reader, function (err, output) {
       expect(err).to.exist
       expect(err).to.be.instanceof(Error)
       expect(output).to.not.exist
       done()
     })
-
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -91,7 +91,7 @@ describe('pull-length-prefixed', () => {
 
   it.skip('invalid prefix', (done) => {
     const input = [
-      new Buffer('br34k mai h34rt'),
+      new Buffer('br34k mai h34rt')
     ]
 
     pull(
@@ -99,7 +99,7 @@ describe('pull-length-prefixed', () => {
       pull.values(input),
       lp.encode(),
       // corrupt data
-      pull.map(data => data.slice(0,-6)),
+      pull.map(data => data.slice(0, -6)),
       // attempt decode
       lp.decode(),
       pull.collect((err, output) => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -89,6 +89,28 @@ describe('pull-length-prefixed', () => {
     )
   })
 
+  it('invalid prefix', (done) => {
+    const input = [
+      new Buffer('br34k mai h34rt'),
+    ]
+
+    pull(
+      // encode valid input
+      pull.values(input),
+      lp.encode(),
+      // corrupt data
+      pull.map(data => data.slice(0,-6)),
+      // attempt decode
+      lp.decode(),
+      pull.collect((err, output) => {
+        expect(err).to.exist
+        expect(err).to.be.instanceof(Error)
+        expect(output).to.not.exist
+        done()
+      })
+    )
+  })
+
   const sizes = [1, 2, 4, 6, 10, 100, 1000]
 
   sizes.forEach((size) => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -89,7 +89,7 @@ describe('pull-length-prefixed', () => {
     )
   })
 
-  it('invalid prefix', (done) => {
+  it.skip('invalid prefix', (done) => {
     const input = [
       new Buffer('br34k mai h34rt'),
     ]


### PR DESCRIPTION
pull streams emit 'true' or an error on drain.
( see https://github.com/pull-stream/pull-stream#source-aka-readable )

I was getting a case where the source was unexpectedly ending, and 'true' was being passed up as the error. decodeFromReader seemed like the correct place to handle this case, as it is the end of pull streams and the start of a error-first-cb api.

I fixed that issue and added some additional protections.

note: the `invalid prefix` test is skipped until resolution of this issue: https://github.com/dominictarr/pull-reader/issues/5