### PR TITLE
refactor: Drop 'bytes' arg from fixed because readInt32BE reads exactly 4 bytes, always

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ pull(
 ### `encode([opts])`
 
 - `opts: Object`, optional
-  - `fixed: false`:
-  - `bytes: 4`: If `fixed` is `true` this is the amount of bytes used for the prefix.
+  - `fixed: false`: If true uses a fixed 4 byte Int32BE prefix instead of varint
 
 By default all messages will be prefixed with a varint. If you want to use a fixed length prefix you can specify this through the `opts`.
 
@@ -68,8 +67,7 @@ Returns a pull-stream through.
 ### `decode([opts])`
 
 - `opts: Object`, optional
-  - `fixed: false`:
-  - `bytes: 4`: If `fixed` is `true` this is the amount of bytes used for the prefix.
+  - `fixed: false`: If true uses a fixed 4 byte Int32BE prefix instead of varint
   - `maxLength`: If provided, will not decode messages longer than the size specified, if omitted will use the current default of 4MB.
 
 By default all messages will be prefixed with a varint. If you want to use a fixed length prefix you can specify this through the `opts`.

--- a/src/decode.js
+++ b/src/decode.js
@@ -41,29 +41,28 @@ function decodeFromReader (reader, opts, cb) {
   }
 
   opts = Object.assign({
-    fixed: false,
-    bytes: 4
+    fixed: false
   }, opts || {})
 
   if (opts.fixed) {
-    readFixedMessage(reader, opts.bytes, opts.maxLength, cb)
+    readFixedMessage(reader, opts.maxLength, cb)
   } else {
     readVarintMessage(reader, opts.maxLength, cb)
   }
 }
 
-function readFixedMessage (reader, byteLength, maxLength, cb) {
+function readFixedMessage (reader, maxLength, cb) {
   if (typeof maxLength === 'function') {
     cb = maxLength
     maxLength = MAX_LENGTH
   }
 
-  reader.read(byteLength, (err, bytes) => {
+  reader.read(4, (err, bytes) => {
     if (err) {
       return cb(err)
     }
 
-    const msgSize = bytes.readInt32BE(0)
+    const msgSize = bytes.readInt32BE(0) // reads exactly 4 bytes
     if (msgSize > maxLength) {
       return cb('size longer than max permitted length of ' + maxLength + '!')
     }

--- a/src/encode.js
+++ b/src/encode.js
@@ -8,8 +8,7 @@ const poolSize = 10 * 1024
 
 function encode (opts) {
   opts = Object.assign({
-    fixed: false,
-    bytes: 4
+    fixed: false
   }, opts || {})
 
   // Only needed for varint
@@ -34,8 +33,8 @@ function encode (opts) {
 
       let encodedLength
       if (opts.fixed) {
-        encodedLength = Buffer.alloc(opts.bytes)
-        encodedLength.writeInt32BE(data.length, 0)
+        encodedLength = Buffer.alloc(4)
+        encodedLength.writeInt32BE(data.length, 0) // writes exactly 4 bytes
       } else {
         varint.encode(data.length, pool, used)
         used += varint.encode.bytes


### PR DESCRIPTION
You can verify this by taking a look at https://github.com/nodejs/node/blob/1d2fd8b65bacaf4401450edc8ed529106cbcfc67/lib/internal/buffer.js#L360-L371