### PR TITLE
Zero-length streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "varint": "^5.0.0"
   },
   "devDependencies": {
-    "aegir": "^11.0.1",
-    "chai": "^4.1.2",
+    "aegir": "^18.0.3",
+    "chai": "^4.2.0",
     "pull-block": "^1.2.0",
-    "pull-stream": "^3.5.0"
+    "pull-stream": "^3.6.9"
   },
   "contributors": [
     "Dmitriy Ryajov <dryajov@gmail.com>",

--- a/src/decode.js
+++ b/src/decode.js
@@ -100,22 +100,24 @@ function readVarintMessage (reader, maxLength, cb) {
       if (msgSize > maxLength) {
         return cb(new Error('size longer than max permitted length of ' + maxLength + '!'))
       }
-      if (msgSize > 0) {
-        readMessage(reader, msgSize, (err, msg) => {
-          if (err) {
-            return cb(err)
-          }
-  
-          rawMsgSize = []
-  
-          if (msg.length < msgSize) {
-            return cb(new Error('Message length does not match prefix specified length.'))
-          }
-          cb(null, msg)
-        })
-      } else {
-        cb(true)
+
+      if (msgSize <= 0) {
+        return cb(true)
       }
+
+      readMessage(reader, msgSize, (err, msg) => {
+        if (err) {
+          return cb(err)
+        }
+
+        rawMsgSize = []
+
+        if (msg.length < msgSize) {
+          return cb(new Error('Message length does not match prefix specified length.'))
+        }
+        cb(null, msg)
+      })
+
     })
   }
 }

--- a/src/decode.js
+++ b/src/decode.js
@@ -100,18 +100,22 @@ function readVarintMessage (reader, maxLength, cb) {
       if (msgSize > maxLength) {
         return cb(new Error('size longer than max permitted length of ' + maxLength + '!'))
       }
-      readMessage(reader, msgSize, (err, msg) => {
-        if (err) {
-          return cb(err)
-        }
-
-        rawMsgSize = []
-
-        if (msg.length < msgSize) {
-          return cb(new Error('Message length does not match prefix specified length.'))
-        }
-        cb(null, msg)
-      })
+      if (msgSize > 0) {
+        readMessage(reader, msgSize, (err, msg) => {
+          if (err) {
+            return cb(err)
+          }
+  
+          rawMsgSize = []
+  
+          if (msg.length < msgSize) {
+            return cb(new Error('Message length does not match prefix specified length.'))
+          }
+          cb(null, msg)
+        })
+      } else {
+        cb(true)
+      }
     })
   }
 }

--- a/src/decode.js
+++ b/src/decode.js
@@ -20,16 +20,35 @@ function decode (opts) {
 
   return (read) => {
     reader(read)
+    
     function next () {
-      _decodeFromReader(reader, opts, (err, msg) => {
-        if (err) return p.end(err)
+      let doNext = true
+      let decoded = false
 
-        p.push(msg)
-        next()
-      })
+      const decodeCb = (err, msg) => {
+        decoded = true
+        if (err) {
+          p.end(err)
+          doNext = false
+        } else {
+          p.push(msg)
+          if (!doNext) {
+            next()
+          }
+        }
+      }
+
+      while (doNext) {
+        decoded = false
+        _decodeFromReader(reader, opts, decodeCb)
+        if (!decoded) {
+          doNext = false
+        }
+      }
     }
 
     next()
+
     return p
   }
 }

--- a/src/encode.js
+++ b/src/encode.js
@@ -16,7 +16,7 @@ function encode (opts) {
   let pool = opts.fixed ? null : createPool()
   let used = 0
 
-  let ended = false
+  let ended = false, first = true
 
   return (read) => (end, cb) => {
     if (end) ended = end
@@ -24,7 +24,14 @@ function encode (opts) {
 
     read(null, (end, data) => {
       if (end) ended = end
-      if (ended) return cb(ended)
+      if (ended) {
+        if (first) {
+          data = Buffer.alloc(0)
+        } else {
+          return cb(ended)
+        }
+      }
+      first = false
 
       if (!Buffer.isBuffer(data)) {
         ended = new Error('data must be a buffer')
@@ -45,7 +52,7 @@ function encode (opts) {
           used = 0
         }
       }
-
+      
       cb(null, Buffer.concat([
         encodedLength,
         data

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -96,6 +96,35 @@ describe('pull-length-prefixed', () => {
     )
   })
 
+  it('zero length', (done) => {
+    pull(
+      pull.values(),
+      lp.encode(),
+      pull.collect((err, encoded) => {
+        if (err) throw err
+
+        expect(
+          encoded
+        ).to.be.eql([Buffer.alloc(1, 0)])
+
+        pull(
+          pull.values(),
+          lp.encode(),
+          lp.decode(),
+          pull.collect((err, decoded) => {
+            if (err) throw err
+
+            expect(
+              decoded
+            ).to.be.eql([])
+
+            done()
+          })
+        )
+      })
+    )
+  })
+
   it('push time based', (done) => {
     const p = new Pushable()
     const input = []

--- a/test/syncStream.spec.js
+++ b/test/syncStream.spec.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+'use strict'
+
+const Buffer = require('safe-buffer').Buffer
+
+const pull = require('pull-stream')
+const expect = require('chai').expect
+const varint = require('varint')
+
+const lp = require('../src')
+
+describe('pull-length-prefixed', () => {
+  it('sync stream', (done) => {
+    const input = [...Array(500).keys()].map(() => Buffer.from('payload'))
+
+    pull(
+      pull.values(input),
+      lp.encode(),
+      pull.collect((err, encoded) => {
+        if (err) throw err
+
+        expect(
+          encoded
+        ).to.be.eql(
+          input.map(data => {
+            const len = varint.encode(data.length)
+            return Buffer.concat([
+              Buffer.alloc(len.length, len, 'utf8'),
+              Buffer.alloc(data.length, data, 'utf8')
+            ])
+          }))
+
+        pull(
+          pull.values(encoded),
+          lp.decode(),
+          pull.collect((err, output) => {
+            if (err) throw err
+            expect(
+              input
+            ).to.be.eql(
+              output
+            )
+            done()
+          })
+        )
+      })
+    )
+  })
+})


### PR DESCRIPTION
The current implementation leads to exceptions when it is used to encode zero-length streams. To ensure that, I'd suggest the following enhancements:

- The encoder adds a `Buffer('0x00', 'hex')` in case `msgSize` is `0`.
- The decoder reads the first bit and determines whether the `msgSize` is `0` and tries to read the message only if `msgSize > 0`
- Compute `data.length` only once and prevent `Buffer.concat` from computing the length again.

Purpose of the enhancements:
When using the library in combination with libp2p, it happens once in a while that some nodes answer with empty messages that leads to an exception at the receiver when using length-prefixed pull-streams. In general, empty messages doesn't make any sense. But when using it in a p2p context, they're useful to tell other nodes that they cannot help with that issue and have therefore no answer.

Thanks in advance ;-)
Robert