### PR TITLE
fix: empty streams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - 8
-  - stable
+  - 10
 
 # Make sure we have new NPM and yarn
 before_install:

--- a/src/decode.js
+++ b/src/decode.js
@@ -122,10 +122,6 @@ function readVarintMessage (reader, maxLength, cb) {
         return cb(new Error('size longer than max permitted length of ' + maxLength + '!'))
       }
 
-      if (msgSize <= 0) {
-        return cb(true) // eslint-disable-line standard/no-callback-literal
-      }
-
       readMessage(reader, msgSize, (err, msg) => {
         if (err) {
           return cb(err)

--- a/src/encode.js
+++ b/src/encode.js
@@ -17,7 +17,6 @@ function encode (opts) {
   let used = 0
 
   let ended = false
-  let first = true
 
   return (read) => (end, cb) => {
     if (end) ended = end
@@ -25,11 +24,7 @@ function encode (opts) {
 
     read(null, (end, data) => {
       if (end) ended = end
-      if (ended && !first) {
-        return cb(ended)
-      }
-
-      first = false
+      if (ended) return cb(ended)
 
       if (!ended && !Buffer.isBuffer(data)) {
         ended = new Error('data must be a buffer')

--- a/test/fromReader.spec.js
+++ b/test/fromReader.spec.js
@@ -48,8 +48,9 @@ describe('pull-length-prefixed decodeFromReader', () => {
 
     // decode from reader
     lp.decodeFromReader(reader, function (err, output) {
-      expect(output).to.eql(Buffer.alloc(0))
-      done(err)
+      expect(err).to.be.instanceof(Error)
+      expect(output).to.equal(undefined)
+      done()
     })
   })
 })

--- a/test/fromReader.spec.js
+++ b/test/fromReader.spec.js
@@ -48,9 +48,8 @@ describe('pull-length-prefixed decodeFromReader', () => {
 
     // decode from reader
     lp.decodeFromReader(reader, function (err, output) {
-      expect(err).to.be.instanceof(Error)
-      expect(output).to.equal(undefined)
-      done()
+      expect(output).to.eql(Buffer.alloc(0))
+      done(err)
     })
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -108,7 +108,10 @@ describe('pull-length-prefixed', () => {
         ).to.be.eql([Buffer.alloc(1, 0)])
 
         pull(
-          pull.values(),
+          pull.values([
+            Buffer.alloc(0),
+            Buffer.from('more data')
+          ]),
           lp.encode(),
           lp.decode(),
           pull.collect((err, decoded) => {
@@ -116,7 +119,10 @@ describe('pull-length-prefixed', () => {
 
             expect(
               decoded
-            ).to.be.eql([])
+            ).to.be.eql([
+              Buffer.alloc(0),
+              Buffer.from('more data')
+            ])
 
             done()
           })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -101,11 +101,8 @@ describe('pull-length-prefixed', () => {
       pull.values(),
       lp.encode(),
       pull.collect((err, encoded) => {
-        if (err) throw err
-
-        expect(
-          encoded
-        ).to.be.eql([Buffer.alloc(1, 0)])
+        expect(err).to.eql(null)
+        expect(encoded).to.eql([])
 
         pull(
           pull.values([


### PR DESCRIPTION
The recent update to better support empty streams was ending streams when an empty value was decoded, it shouldn't, as this prevents other values from being returned. A receiver may respond with an empty message and then continue to write subsequent responses on the same stream.